### PR TITLE
Add config for webhook url to work with the Slack API updates

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -8,7 +8,7 @@
 
     <match slack>
       type buffered_slack
-      api_key XXX
+      webhook_url https://hooks.slack.com/services/XXX/XXX/XXX
       team sowa
       channel %23general # You should use %23 in return for #
       username sowasowa

--- a/lib/fluent/plugin/out_buffered_slack.rb
+++ b/lib/fluent/plugin/out_buffered_slack.rb
@@ -11,6 +11,7 @@ module Fluent
     config_param :icon_emoji, :string
     config_param :timezone,   :string, default: nil
     config_param :rtm,        :bool  , default: false
+    config_param :webhook_url,:string, default: nil
 
     attr_reader :slack
 
@@ -82,6 +83,7 @@ module Fluent
         @timezone   = conf['timezone'] || 'UTC'
         @team       = conf['team']
         @api_key    = conf['api_key']
+        @webhook_url= conf['webhook_url']
       end
     end
 
@@ -103,7 +105,7 @@ module Fluent
     end
 
     def endpoint
-      URI.parse "https://#{@team}.slack.com/services/hooks/incoming-webhook?token=#{@api_key}"
+      URI.parse @webhook_url || "https://#{@team}.slack.com/services/hooks/incoming-webhook?token=#{@api_key}"
     end
 
     def post_request(data)


### PR DESCRIPTION
incoming webhook endpoint was changed to https://hooks.slack.com/services/XXX/YYY/ZZZ