### PR TITLE
Add auto_channels_create option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ fluent_logger.post('slack', {
 |title_keys|keys used to format the title|nil|
 |message|message format. %s will be replaced with value specified by message_keys|%s|
 |message_keys|keys used to format messages|message|
+|auto_channel_create|Create channels if not exist. Available only with Web API mode, and a token for Normal User is required (Bot User can not create channels. See https://api.slack.com/bot-users)|false|
 
 `fluent-plugin-slack` uses `SetTimeKeyMixin` and `SetTagKeyMixin`, so you can also use:
 

--- a/lib/fluent/plugin/slack_client.rb
+++ b/lib/fluent/plugin/slack_client.rb
@@ -1,51 +1,19 @@
 require 'uri'
 require 'net/http'
+require 'logger'
+require_relative 'slack_client/error'
 
 module Fluent
   module SlackClient
-    class Error < StandardError; end
-
-    # This slack client only supports posting message
+    # The base framework of slack client
     class Base
       attr_accessor :log, :debug_dev
 
-      DEFAULT_ENDPOINT = "https://slack.com/api/chat.postMessage"
-
-      def initialize(endpoint = nil)
-        # Configure Incoming Webhook endpoint instead of chat.postMessage API
-        @endpoint = URI.parse(endpoint) if endpoint
+      def initialize
+        @log = Logger.new('/dev/null')
       end
 
-      def endpoint
-        @endpoint ||= URI.parse(DEFAULT_ENDPOINT)
-      end
-
-      # Sends a message to a channel.
-      #
-      # @option params [channel] :channel
-      #   Channel to send message to. Can be a public channel, private group or IM channel. Can be an encoded ID, or a name.
-      # @option params [Object] :text
-      #   Text of the message to send. See below for an explanation of formatting.
-      # @option params [Object] :username
-      #   Name of bot.
-      # @option params [Object] :parse
-      #   Change how messages are treated. See below.
-      # @option params [Object] :link_names
-      #   Find and link channel names and usernames.
-      # @option params [Object] :attachments
-      #   Structured message attachments.
-      # @option params [Object] :unfurl_links
-      #   Pass true to enable unfurling of primarily text-based content.
-      # @option params [Object] :unfurl_media
-      #   Pass false to disable unfurling of media content.
-      # @option params [Object] :icon_url
-      #   URL to an image to use as the icon for this message
-      # @option params [Object] :icon_emoji
-      #   emoji to use as the icon for this message. Overrides `icon_url`.
-      # @see https://api.slack.com/methods/chat.postMessage
-      # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/chat.postMessage.md
-      # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/chat.postMessage.json
-      def post_message(params = {})
+      def post(endpoint, params)
         http = Net::HTTP.new(endpoint.host, endpoint.port)
         http.use_ssl = (endpoint.scheme == 'https')
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
@@ -57,36 +25,100 @@ module Fluent
         req['User-Agent'] = 'fluent-plugin-slack'
         req.body = encode_body(params)
 
-        log.info { "out_slack: post #{params.dup.tap {|p| p[:token] = '[FILTERED]' if p[:token] }}" } if log
         res = http.request(req)
-        response_check(res)
+        response_check(res, params)
       end
+
+      private
 
       def encode_body(params)
         raise NotImplementedError
       end
 
-      def response_check(res)
+      def response_check(res, params)
         if res.code != "200"
-          raise Error, "Slack.com - #{res.code} - #{res.body}"
+          raise Error.new(res, params)
         end
       end
     end
 
+    # Slack client for Incoming Webhook
     class IncomingWebhook < Base
+      attr_accessor :endpoint
+
+      # @param [String] endpoint Configure Incoming Webhook endpoint
+      def initialize(endpoint)
+        super()
+        @endpoint = URI.parse(endpoint)
+      end
+
+      def post_message(params = {}, opts = {})
+        log.info { "out_slack: post_message #{params}" }
+        post(endpoint, params)
+      end
+
+      private
+
       def encode_body(params = {})
         params.to_json
       end
 
-      def response_check(res)
+      def response_check(res, params)
         super
         unless res.body == 'ok'
-          raise Error, "Slack.com - #{res.code} - #{res.body}"
+          raise Error.new(res, params)
         end
       end
     end
 
+    # Slack client for Web API
     class WebApi < Base
+      DEFAULT_ENDPOINT = "https://slack.com/api/".freeze
+
+      def post_message_endpoint
+        @post_message_endpoint    ||= URI.join(DEFAULT_ENDPOINT, "chat.postMessage")
+      end
+
+      def channels_create_endpoint
+        @channels_create_endpoint ||= URI.join(DEFAULT_ENDPOINT, "channels.create")
+      end
+
+      # Sends a message to a channel.
+      #
+      # @see https://api.slack.com/methods/chat.postMessage
+      # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/chat.postMessage.md
+      # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/chat.postMessage.json
+      def post_message(params = {}, opts = {})
+        retries = 1
+        begin
+          log.info { "out_slack: post_message #{params.dup.tap {|p| p[:token] = '[FILTERED]' if p[:token] }}" }
+          post(post_message_endpoint, params)
+        rescue ChannelNotFoundError => e
+          if opts[:auto_channels_create]
+            log.warn "out_slack: channel \"#{params[:channel]}\" is not found. try to create the channel, and then retry to post the message."
+            channels_create({name: params[:channel], token: params[:token]})
+            retry if (retries -= 1) >= 0 # one time retry
+          else
+            raise e
+          end
+        end
+      end
+
+      # Creates a channel.
+      #
+      # NOTE: Bot user can not create a channel. Token must be issued by Normal User Account
+      # @see https://api.slack.com/bot-users
+      #
+      # @see https://api.slack.com/methods/channels.create
+      # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/channels.create.md
+      # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/channels.create.json
+      def channels_create(params = {}, opts = {})
+        log.info { "out_slack: channels_create #{params.dup.tap {|p| p[:token] = '[FILTERED]' if p[:token] }}" }
+        post(channels_create_endpoint, params)
+      end
+
+      private
+
       def encode_body(params = {})
         body = params.dup
         if params[:attachments]
@@ -95,11 +127,17 @@ module Fluent
         URI.encode_www_form(body)
       end
 
-      def response_check(res)
+      def response_check(res, params)
         super
-        params = JSON.parse(res.body)
-        unless params['ok']
-          raise Error, "Slack.com - #{res.code} - #{res.body}"
+        res_params = JSON.parse(res.body)
+        return if res_params['ok']
+        case res_params['error']
+        when 'channel_not_found'
+          raise ChannelNotFoundError.new(res, params)
+        when 'name_taken'
+          raise NameTakenError.new(res, params)
+        else
+          raise Error.new(res, params)
         end
       end
     end

--- a/lib/fluent/plugin/slack_client/error.rb
+++ b/lib/fluent/plugin/slack_client/error.rb
@@ -1,0 +1,24 @@
+require 'net/http'
+
+module Fluent
+  module SlackClient
+    class Error < StandardError
+      attr_reader :res, :req_params
+
+      def initialize(res, req_params = {})
+        @res        = res
+        @req_params = req_params.dup
+      end
+
+      def message
+        @req_params[:token] = '[FILTERED]' if @req_params[:token]
+        "res.code:#{@res.code}, res.body:#{@res.body}, req_params:#{@req_params}"
+      end
+
+      alias :to_s :message
+    end
+
+    class ChannelNotFoundError < Error; end
+    class NameTakenError < Error; end
+  end
+end

--- a/test/plugin/test_out_slack.rb
+++ b/test/plugin/test_out_slack.rb
@@ -129,7 +129,7 @@ class SlackOutputTest < Test::Unit::TestCase
     ])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
     d.tag  = 'test'
-    mock(d.instance.slack).post_message(
+    mock(d.instance.slack).post_message({
       channel:     '#channel',
       username:    'fluentd',
       icon_emoji:  ':question:',
@@ -141,7 +141,7 @@ class SlackOutputTest < Test::Unit::TestCase
           value: "[07:00:00] sowawa1\n[07:00:00] sowawa2\n",
         }],
       }]
-    )
+    }, {})
     with_timezone('Asia/Tokyo') do
       d.emit({message: 'sowawa1'}, time)
       d.emit({message: 'sowawa2'}, time)
@@ -156,7 +156,7 @@ class SlackOutputTest < Test::Unit::TestCase
     ])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
     d.tag  = 'test'
-    mock(d.instance.slack).post_message(
+    mock(d.instance.slack).post_message({
       token:       'XX-XX-XX',
       channel:     '#channel',
       username:    'fluentd',
@@ -166,7 +166,7 @@ class SlackOutputTest < Test::Unit::TestCase
         fallback: "sowawa1\nsowawa2\n",
         text:     "sowawa1\nsowawa2\n",
       }]
-    )
+    }, {})
     with_timezone('Asia/Tokyo') do
       d.emit({message: 'sowawa1'}, time)
       d.emit({message: 'sowawa2'}, time)
@@ -179,7 +179,7 @@ class SlackOutputTest < Test::Unit::TestCase
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
     d.tag  = 'test'
     # attachments field should be changed to show the title
-    mock(d.instance.slack).post_message(
+    mock(d.instance.slack).post_message({
       token:       'XXX-XXX-XXX',
       channel:     '#channel',
       username:    'fluentd',
@@ -194,7 +194,7 @@ class SlackOutputTest < Test::Unit::TestCase
           }
         ]
       }]
-    )
+    }, {})
     with_timezone('Asia/Tokyo') do
       d.emit({message: 'sowawa1'}, time)
       d.emit({message: 'sowawa2'}, time)
@@ -206,7 +206,7 @@ class SlackOutputTest < Test::Unit::TestCase
     d = create_driver(CONFIG + %[message %s %s\nmessage_keys tag,message])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
     d.tag  = 'test'
-    mock(d.instance.slack).post_message(
+    mock(d.instance.slack).post_message({
       token:       'XXX-XXX-XXX',
       channel:     '#channel',
       username:    'fluentd',
@@ -216,7 +216,7 @@ class SlackOutputTest < Test::Unit::TestCase
         fallback: "test sowawa1\ntest sowawa2\n",
         text:     "test sowawa1\ntest sowawa2\n",
       }]
-    )
+    }, {})
     with_timezone('Asia/Tokyo') do
       d.emit({message: 'sowawa1'}, time)
       d.emit({message: 'sowawa2'}, time)
@@ -228,7 +228,7 @@ class SlackOutputTest < Test::Unit::TestCase
     d = create_driver(CONFIG + %[channel %s\nchannel_keys channel])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
     d.tag  = 'test'
-    mock(d.instance.slack).post_message(
+    mock(d.instance.slack).post_message({
       token:       'XXX-XXX-XXX',
       channel:     '#channel1',
       username:    'fluentd',
@@ -238,8 +238,8 @@ class SlackOutputTest < Test::Unit::TestCase
         fallback: "sowawa1\n",
         text:     "sowawa1\n",
       }]
-    )
-    mock(d.instance.slack).post_message(
+    }, {})
+    mock(d.instance.slack).post_message({
       token:       'XXX-XXX-XXX',
       channel:     '#channel2',
       username:    'fluentd',
@@ -249,7 +249,7 @@ class SlackOutputTest < Test::Unit::TestCase
         fallback: "sowawa2\n",
         text:     "sowawa2\n",
       }]
-    )
+    }, {})
     with_timezone('Asia/Tokyo') do
       d.emit({message: 'sowawa1', channel: 'channel1'}, time)
       d.emit({message: 'sowawa2', channel: 'channel2'}, time)

--- a/test/plugin/test_slack_client.rb
+++ b/test/plugin/test_slack_client.rb
@@ -23,7 +23,7 @@ if ENV['WEBHOOK_URL'] and ENV['TOKEN']
       client == @api ? {token: ENV['TOKEN']} : {}
     end
 
-    def test_text
+    def test_post_message_text
       [@incoming_webhook, @api].each do |slack|
         assert_nothing_raised do
           slack.post_message(
@@ -42,7 +42,7 @@ if ENV['WEBHOOK_URL'] and ENV['TOKEN']
       end
     end
 
-    def test_fields
+    def test_post_message_fields
       [@incoming_webhook, @api].each do |slack|
         assert_nothing_raised do
           slack.post_message(
@@ -67,6 +67,41 @@ if ENV['WEBHOOK_URL'] and ENV['TOKEN']
             }.merge(token(slack))
           )
         end
+      end
+    end
+
+    # Hmm, I need to delete channels to test repeatedly,
+    # but slack does not provide channels.delete API
+    def test_channels_create
+      begin
+        @api.channels_create(
+          {
+            name: '#foo',
+          }.merge(token(@api))
+        )
+      rescue Fluent::SlackClient::NameTakenError
+      end
+    end
+
+    # Hmm, I need to delete channels to test repeatedly,
+    # but slack does not provide channels.delete API
+    def test_auto_channels_create
+      assert_nothing_raised do
+        @api.post_message(
+          {
+            channel:     '#bar',
+            username:    'fluentd',
+            icon_emoji:  ':question:',
+            attachments: [{
+              color:    'good',
+              fallback: "bar\n",
+              text:     "bar\n",
+            }]
+          }.merge(token(@api)),
+          {
+            auto_channels_create: true,
+          }
+        )
       end
     end
   end


### PR DESCRIPTION
I added `auto_channels_create` option which enables to create a channel automatically if it does not exist. 

This option is available only for Web API with a token of a Normal User (Bot User can not create a channel). See https://api.slack.com/bot-users for Normal User and Bot User. 