### PR TITLE
Add `mrkdwn` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ fluent_logger.post('slack', {
 |color|color to use|good|
 |icon_emoji|emoji to use as the icon. either of icon_emoji or icon_url can be specified|`:question:`|
 |icon_url|url to an image to use as the icon. either of icon_emoji or icon_url can be specified|nil|
+|mrkdwn|enable formatting. see https://api.slack.com/docs/formatting|false|
 |channel|channel to send messages (without first '#')||
 |channel_keys|keys used to format channel. %s will be replaced with value specified by channel_keys if this option is used|nil|
 |title|title format. %s will be replaced with value specified by title_keys. title is created from the first appeared record on each tag|nil|

--- a/test/plugin/test_out_slack.rb
+++ b/test/plugin/test_out_slack.rb
@@ -172,6 +172,18 @@ class SlackOutputTest < Test::Unit::TestCase
     assert_not_equal Net::HTTP, d.instance.slack.proxy_class # Net::HTTP.Proxy
   end
 
+  def test_mrkwn_configure
+    # default
+    d = create_driver(CONFIG)
+    assert_equal false, d.instance.mrkdwn
+    assert_equal nil, d.instance.mrkdwn_in
+
+    # mrkdwn
+    d = create_driver(CONFIG + %[mrkdwn true])
+    assert_equal true, d.instance.mrkdwn
+    assert_equal %w[text fields], d.instance.mrkdwn_in
+  end
+
   def test_default_incoming_webhook
     d = create_driver(%[
       channel channel
@@ -242,7 +254,7 @@ class SlackOutputTest < Test::Unit::TestCase
             title: d.tag,
             value: "sowawa1\nsowawa2\n",
           }
-        ]
+        ],
       }]
     }, {})
     with_timezone('Asia/Tokyo') do
@@ -341,6 +353,28 @@ class SlackOutputTest < Test::Unit::TestCase
         color:    'good',
         fallback: "foo\n",
         text:     "foo\n",
+      }]
+    }, {})
+    with_timezone('Asia/Tokyo') do
+      d.emit({message: 'foo'}, time)
+      d.run
+    end
+  end
+
+  def test_mrkdwn
+    d = create_driver(CONFIG + %[mrkdwn true])
+    time = Time.parse("2014-01-01 22:00:00 UTC").to_i
+    d.tag  = 'test'
+    mock(d.instance.slack).post_message({
+      token:       'XXX-XXX-XXX',
+      channel:     '#channel',
+      username:    'fluentd',
+      icon_emoji:  ':question:',
+      attachments: [{
+        color:    'good',
+        fallback: "foo\n",
+        text:     "foo\n",
+        mrkdwn_in: ["text", "fields"],
       }]
     }, {})
     with_timezone('Asia/Tokyo') do

--- a/test/plugin/test_slack_client.rb
+++ b/test/plugin/test_slack_client.rb
@@ -114,7 +114,7 @@ if ENV['WEBHOOK_URL'] and ENV['TOKEN']
     end
 
     def test_post_message_icon_url
-      [@incoming_webhook, @api, @incoming_webhook_proxy, @api_proxy].each do |slack|
+      [@incoming_webhook, @api].each do |slack|
         assert_nothing_raised do
           slack.post_message(
             {
@@ -125,6 +125,49 @@ if ENV['WEBHOOK_URL'] and ENV['TOKEN']
                 color:    'good',
                 fallback: "sowawa1\nsowawa2\n",
                 text:     "sowawa1\nsowawa2\n",
+              }]
+            }.merge(token(slack))
+          )
+        end
+      end
+    end
+
+    def test_post_message_text_mrkdwn
+      [@incoming_webhook, @api].each do |slack|
+        assert_nothing_raised do
+          slack.post_message(
+            {
+              channel:     '#general',
+              username:    'fluentd',
+              attachments: [{
+                color:    'good',
+                fallback: "plain *bold* _italic_ `preformat`\n", # mrkdwn not work
+                text:     "plain *bold* _italic_ `preformat`\n",
+                mrkdwn_in: ['text', 'fields'],
+              }]
+            }.merge(token(slack))
+          )
+        end
+      end
+    end
+
+    def test_post_message_fields_mrkdwn
+      [@incoming_webhook, @api].each do |slack|
+        assert_nothing_raised do
+          slack.post_message(
+            {
+              channel:     '#general',
+              username:    'fluentd',
+              attachments: [{
+                color:    'good',
+                fallback: "plain *bold* _italic_ `preformat`\n", # mrkdwn not work
+                fields:   [
+                  {
+                    title: 'plain *bold* _italic* `preformat`', # mrkdwn not work
+                    value: "plain *bold* _italic* `preformat`\n",
+                  },
+                ],
+                mrkdwn_in: ['text', 'fields'],
               }]
             }.merge(token(slack))
           )


### PR DESCRIPTION
To enable formatting in attachment fields, we have to set `mrkdwn_in` parameter for Slack API. See the bottom of https://api.slack.com/docs/formatting. 

The `mrkdwn` bool option enables formatting for fluent-plugin-slack.