### PR TITLE
escape special characters in message.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ rvm:
   - 2.2.*
 gemfile:
   - Gemfile
+before_install:
+  - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,3 @@ rvm:
   - 2.2.*
 gemfile:
   - Gemfile
-before_install:
-  - gem update bundler

--- a/lib/fluent/plugin/slack_client.rb
+++ b/lib/fluent/plugin/slack_client.rb
@@ -114,7 +114,8 @@ module Fluent
       private
 
       def encode_body(params = {})
-        params.to_json
+        # https://api.slack.com/docs/formatting
+        params.to_json.gsub(/&/, '&amp;').gsub(/</, '&lt;').gsub(/>/, '&gt;')
       end
 
       def response_check(res, params)


### PR DESCRIPTION
I couldn't post message includes `&token=` via fluent-plugin-slack.
See also https://api.slack.com/docs/formatting.

fluentd.conf
```
<source>
  type forward
</source>
<match slack.**>
  type slack
  webhook_url https://hooks.slack.com/services/xxxx/yyyyy
  channel sandbox
  message_keys message
  message "%s"
  flush_interval 1s
</match>
```

post an event to fluentd.
```
$ echo '{"message":"&token="}' | fluent-cat slack
```

Slack returns "Bad token" error.
```
2015-12-17 17:23:32 +0900 [info]: listening fluent socket on 0.0.0.0:24224
2015-12-17 17:23:34 +0900 [info]: out_slack: post_message {:channel=>"#sandbox", :text=>"&token=\n", :mrkdwn=>true, :link_names=>true}
2015-12-17 17:23:35 +0900 [error]: out_slack: error="res.code:404, res.body:Bad token, req_params:{:channel=>\"#sandbox\", :text=>\"&token=\\n\", :mrkdwn=>true, :link_names=>true}" error_class="Fluent::SlackClient::Error"
```