### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.3.0
 gemfile:
   - Gemfile
-  - Gemfile.fluentd.0.12
 matrix:
   exclude:
     - rvm: 2.0.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 sudo: false
 rvm:
-  - 2.0.*
   - 2.1.*
   - 2.2.*
-  - 2.3.0
+  - 2.3.1
 gemfile:
   - Gemfile
-matrix:
-  exclude:
-    - rvm: 2.0.*
-      gemfile: Gemfile
 before_install:
   - gem update bundler

--- a/Gemfile.fluentd.0.12
+++ b/Gemfile.fluentd.0.12
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec
-gem 'fluentd', '~> 0.12.0'

--- a/fluent-plugin-slack.gemspec
+++ b/fluent-plugin-slack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", ">= 0.10.8"
+  gem.add_dependency "fluentd", [">= 0.14.8", "< 2"]
 
   gem.add_development_dependency "rake", ">= 10.1.1"
   gem.add_development_dependency "rr", ">= 1.0.0"

--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -133,7 +133,7 @@ DESC
     def configure(conf)
       conf['time_format'] ||= '%H:%M:%S' # old version compatiblity
       conf['localtime'] ||= true unless conf['utc']
-      compat_parameters_convert(conf, :inject)
+      compat_parameters_convert(conf, :inject, :buffer)
 
       super
 

--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -10,20 +10,6 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
 
-    # For fluentd v0.12.16 or earlier
-    class << self
-      unless method_defined?(:desc)
-        def desc(description)
-        end
-      end
-    end
-
-    include Fluent::SetTimeKeyMixin
-    include Fluent::SetTagKeyMixin
-
-    config_set_default :include_time_key, true
-    config_set_default :include_tag_key, true
-
     desc <<-DESC
 Incoming Webhook URI (Required for Incoming Webhook mode).
 See: https://api.slack.com/incoming-webhooks
@@ -123,6 +109,8 @@ DESC
 
     desc "Include messages to the fallback attributes"
     config_param :verbose_fallback,     :bool,   default: false
+
+    config_set_default :time_format, "%H:%M:%S"
 
     config_section :inject, param_name: :inject_config do
       config_set_default :tag_key, "tag"

--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'fluent/plugin/output'
 require_relative 'slack_client'
 
@@ -127,7 +128,6 @@ DESC
 
     def initialize
       super
-      require 'uri'
     end
 
     def configure(conf)

--- a/test/plugin/test_out_slack.rb
+++ b/test/plugin/test_out_slack.rb
@@ -1,5 +1,7 @@
+# coding: utf-8
 require_relative '../test_helper'
 require 'fluent/plugin/out_slack'
+require 'fluent/test/driver/output'
 require 'time'
 
 class SlackOutputTest < Test::Unit::TestCase
@@ -29,8 +31,8 @@ class SlackOutputTest < Test::Unit::TestCase
     }
   end
 
-  def create_driver(conf = CONFIG)
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::SlackOutput).configure(conf)
+  def create_driver(conf = CONFIG, syntax: :v1)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::SlackOutput).configure(conf, syntax: syntax)
   end
 
   # old version compatibility with v0.4.0"
@@ -270,14 +272,14 @@ class SlackOutputTest < Test::Unit::TestCase
     ])
     assert_equal Fluent::SlackClient::IncomingWebhook, d.instance.slack.class
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       text: "sowawa1\nsowawa2\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1'}, time)
-      d.emit({message: 'sowawa2'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'sowawa1'})
+        d.feed(time, {message: 'sowawa2'})
+      end
     end
   end
 
@@ -288,14 +290,14 @@ class SlackOutputTest < Test::Unit::TestCase
     ])
     assert_equal Fluent::SlackClient::Slackbot, d.instance.slack.class
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       text: "sowawa1\nsowawa2\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1'}, time)
-      d.emit({message: 'sowawa2'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'sowawa1'})
+        d.feed(time, {message: 'sowawa2'})
+      end
     end
   end
 
@@ -306,15 +308,15 @@ class SlackOutputTest < Test::Unit::TestCase
     ])
     assert_equal Fluent::SlackClient::WebApi, d.instance.slack.class
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       token: 'XX-XX-XX',
       text:  "sowawa1\nsowawa2\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1'}, time)
-      d.emit({message: 'sowawa2'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'sowawa1'})
+        d.feed(time, {message: 'sowawa2'})
+      end
     end
   end
 
@@ -322,7 +324,6 @@ class SlackOutputTest < Test::Unit::TestCase
     title = "mytitle"
     d = create_driver(CONFIG + %[title #{title}])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     # attachments field should be changed to show the title
     mock(d.instance.slack).post_message(default_payload.merge({
       attachments: [default_attachment.merge({
@@ -336,9 +337,10 @@ class SlackOutputTest < Test::Unit::TestCase
       })]
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1'}, time)
-      d.emit({message: 'sowawa2'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'sowawa1'})
+        d.feed(time, {message: 'sowawa2'})
+      end
     end
   end
 
@@ -346,7 +348,6 @@ class SlackOutputTest < Test::Unit::TestCase
     title = "mytitle"
     d = create_driver(CONFIG + %[title #{title}\nverbose_fallback true])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     # attachments field should be changed to show the title
     mock(d.instance.slack).post_message(default_payload.merge({
       attachments: [default_attachment.merge({
@@ -360,9 +361,10 @@ class SlackOutputTest < Test::Unit::TestCase
       })]
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1'}, time)
-      d.emit({message: 'sowawa2'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'sowawa1'})
+        d.feed(time, {message: 'sowawa2'})
+      end
     end
   end
 
@@ -370,7 +372,6 @@ class SlackOutputTest < Test::Unit::TestCase
     color = 'good'
     d = create_driver(CONFIG + %[color #{color}])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     # attachments field should be changed to show the title
     mock(d.instance.slack).post_message(default_payload.merge({
       attachments: [default_attachment.merge({
@@ -380,68 +381,69 @@ class SlackOutputTest < Test::Unit::TestCase
       })]
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1'}, time)
-      d.emit({message: 'sowawa2'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'sowawa1'})
+        d.feed(time, {message: 'sowawa2'})
+      end
     end
   end
 
   def test_plain_payload
     d = create_driver(CONFIG)
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     # attachments field should be changed to show the title
     mock(d.instance.slack).post_message(default_payload.merge({
       text: "sowawa1\nsowawa2\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1'}, time)
-      d.emit({message: 'sowawa2'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'sowawa1'})
+        d.feed(time, {message: 'sowawa2'})
+      end
     end
   end
 
   def test_title_keys
-    d = create_driver(CONFIG + %[title [%s] %s\ntitle_keys time,tag])
+    d = create_driver(CONFIG + %[title "[%s] %s"\ntitle_keys time,tag])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     # attachments field should be changed to show the title
+    tag = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       attachments: [default_attachment.merge({
-        fallback: "[07:00:00] #{d.tag}",
+        fallback: "[07:00:00] #{tag}",
         fields:   [
           {
-            title: "[07:00:00] #{d.tag}",
+            title: "[07:00:00] #{tag}",
             value: "sowawa1\nsowawa2\n",
           }
         ],
       })]
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1'}, time)
-      d.emit({message: 'sowawa2'}, time)
-      d.run
+      d.run(default_tag: tag) do
+        d.feed(time, {message: 'sowawa1'})
+        d.feed(time, {message: 'sowawa2'})
+      end
     end
   end
 
   def test_message_keys
-    d = create_driver(CONFIG + %[message [%s] %s %s\nmessage_keys time,tag,message])
+    d = create_driver(CONFIG + %[message "[%s] %s %s"\nmessage_keys time,tag,message])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       text: "[07:00:00] test sowawa1\n[07:00:00] test sowawa2\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1'}, time)
-      d.emit({message: 'sowawa2'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'sowawa1'})
+        d.feed(time, {message: 'sowawa2'})
+      end
     end
   end
 
   def test_channel_keys
     d = create_driver(CONFIG + %[channel %s\nchannel_keys channel])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       channel: '#channel1',
       text:    "sowawa1\n",
@@ -451,58 +453,58 @@ class SlackOutputTest < Test::Unit::TestCase
       text:    "sowawa2\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'sowawa1', channel: 'channel1'}, time)
-      d.emit({message: 'sowawa2', channel: 'channel2'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'sowawa1', channel: 'channel1'})
+        d.feed(time, {message: 'sowawa2', channel: 'channel2'})
+      end
     end
   end
 
   def test_icon_emoji
     d = create_driver(CONFIG + %[icon_emoji :ghost:])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       icon_emoji: ':ghost:',
       text:       "foo\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'foo'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'foo'})
+      end
     end
   end
 
   def test_icon_url
     d = create_driver(CONFIG + %[icon_url #{@icon_url}])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       icon_url: @icon_url,
       text:     "foo\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'foo'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'foo'})
+      end
     end
   end
 
   def test_mrkdwn
     d = create_driver(CONFIG + %[mrkdwn true])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       mrkdwn: true,
       text:   "foo\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'foo'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'foo'})
+      end
     end
   end
 
   def test_mrkdwn_in
     d = create_driver(CONFIG + %[mrkdwn true\ncolor good])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       attachments: [default_attachment.merge({
         color:    "good",
@@ -512,36 +514,37 @@ class SlackOutputTest < Test::Unit::TestCase
       })]
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'foo'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'foo'})
+      end
     end
   end
 
   def test_link_names
     d = create_driver(CONFIG + %[link_names true])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       link_names: true,
       text:       "foo\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'foo'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'foo'})
+      end
     end
   end
 
   def test_parse
     d = create_driver(CONFIG + %[parse full])
     time = Time.parse("2014-01-01 22:00:00 UTC").to_i
-    d.tag  = 'test'
     mock(d.instance.slack).post_message(default_payload.merge({
       parse: "full",
       text:  "foo\n",
     }), {})
     with_timezone('Asia/Tokyo') do
-      d.emit({message: 'foo'}, time)
-      d.run
+      d.run(default_tag: 'test') do
+        d.feed(time, {message: 'foo'})
+      end
     end
   end
 end


### PR DESCRIPTION
Hi, I've tried to migrate using v0.14 API.
Could you review this change?

* Keep Buffered output plugin
* Depends on new tag/time manipulation style instead of old mixin based style