### PR TITLE
Make channel config optional on webhook

### DIFF
--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -16,8 +16,6 @@ module Fluent
     include SetTimeKeyMixin
     include SetTagKeyMixin
 
-    CHANNEL_NONE = :channel_none
-
     config_set_default :include_time_key, true
     config_set_default :include_tag_key, true
 
@@ -305,8 +303,9 @@ DESC
             :fallback => fallback_text, # fallback is the message shown on popup
             :fields   => fields.values.map(&:to_h)
           }.merge(common_attachment)],
-        }.merge(common_payload)
-        merge_channel(msg, channel)
+        }
+        msg.merge!(channel: channel) if channel
+        msg.merge!(common_payload)
       end
     end
 
@@ -323,8 +322,9 @@ DESC
             :fallback => text,
             :text     => text,
           }.merge(common_attachment)],
-        }.merge(common_payload)
-        merge_channel(msg, channel)
+        }
+        msg.merge!(channel: channel) if channel
+        msg.merge!(common_payload)
       end
     end
 
@@ -336,15 +336,10 @@ DESC
         messages[channel] << "#{build_message(record)}\n"
       end
       messages.map do |channel, text|
-        msg = { text: text }.merge(common_payload)
-        merge_channel(msg, channel)
+        msg = {text: text}
+        msg.merge!(channel: channel) if channel
+        msg.merge!(common_payload)
       end
-    end
-
-    def merge_channel(msg, channel)
-      return msg if channel == CHANNEL_NONE
-      msg[:channel] = channel
-      msg
     end
 
     def build_message(record)
@@ -360,7 +355,7 @@ DESC
     end
 
     def build_channel(record)
-      return CHANNEL_NONE if @channel.nil?
+      return nil if @channel.nil?
       return @channel unless @channel_keys
 
       values = fetch_keys(record, @channel_keys)

--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -16,6 +16,8 @@ module Fluent
     include SetTimeKeyMixin
     include SetTagKeyMixin
 
+    CHANNEL_NONE = :channel_none
+
     config_set_default :include_time_key, true
     config_set_default :include_tag_key, true
 
@@ -86,7 +88,7 @@ DESC
     config_param :https_proxy,          :string, default: nil
 
     desc "channel to send messages (without first '#')."
-    config_param :channel,              :string
+    config_param :channel,              :string, default: nil
     desc <<-DESC
 Keys used to format channel.
 %s will be replaced with value specified by channel_keys if this option is used.
@@ -130,11 +132,13 @@ DESC
     def configure(conf)
       conf['time_format'] ||= '%H:%M:%S' # old version compatiblity
       conf['localtime'] ||= true unless conf['utc']
- 
+
       super
 
-      @channel = URI.unescape(@channel) # old version compatibility
-      @channel = '#' + @channel unless @channel.start_with?('#')
+      if @channel
+        @channel = URI.unescape(@channel) # old version compatibility
+        @channel = '#' + @channel unless @channel.start_with?('#')
+      end
 
       if @webhook_url
         if @webhook_url.empty?
@@ -148,6 +152,10 @@ DESC
         if @slackbot_url.empty?
           raise Fluent::ConfigError.new("`slackbot_url` is an empty string")
         end
+        if @channel.nil?
+          raise Fluent::ConfigError.new("`channel` parameter required for Slackbot Remote Control")
+        end
+
         if @username or @color or @icon_emoji or @icon_url
           log.warn "out_slack: `username`, `color`, `icon_emoji`, `icon_url` parameters are not available for Slackbot Remote Control"
         end
@@ -159,6 +167,10 @@ DESC
         if @token.empty?
           raise Fluent::ConfigError.new("`token` is an empty string")
         end
+        if @channel.nil?
+          raise Fluent::ConfigError.new("`channel` parameter required for Slack WebApi")
+        end
+
         @slack = Fluent::SlackClient::WebApi.new
       else
         raise Fluent::ConfigError.new("One of `webhook_url` or `slackbot_url`, or `token` is required")
@@ -184,7 +196,7 @@ DESC
           raise Fluent::ConfigError, "string specifier '%s' for `title` and `title_keys` specification mismatch"
         end
       end
-      if @channel_keys
+      if @channel && @channel_keys
         begin
           @channel % (['1'] * @channel_keys.length)
         rescue ArgumentError
@@ -288,13 +300,13 @@ DESC
                           fields.values.map(&:title).join(' ')
                         end
 
-        {
-          channel: channel,
+        msg = {
           attachments: [{
             :fallback => fallback_text, # fallback is the message shown on popup
             :fields   => fields.values.map(&:to_h)
           }.merge(common_attachment)],
         }.merge(common_payload)
+        merge_channel(msg, channel)
       end
     end
 
@@ -306,13 +318,13 @@ DESC
         messages[channel] << "#{build_message(record)}\n"
       end
       messages.map do |channel, text|
-        {
-          channel: channel,
+        msg = {
           attachments: [{
             :fallback => text,
             :text     => text,
           }.merge(common_attachment)],
         }.merge(common_payload)
+        merge_channel(msg, channel)
       end
     end
 
@@ -324,11 +336,15 @@ DESC
         messages[channel] << "#{build_message(record)}\n"
       end
       messages.map do |channel, text|
-        {
-          channel: channel,
-          text:    text,
-        }.merge(common_payload)
+        msg = { text: text }.merge(common_payload)
+        merge_channel(msg, channel)
       end
+    end
+
+    def merge_channel(msg, channel)
+      return msg if channel == CHANNEL_NONE
+      msg[:channel] = channel
+      msg
     end
 
     def build_message(record)
@@ -344,6 +360,7 @@ DESC
     end
 
     def build_channel(record)
+      return CHANNEL_NONE if @channel.nil?
       return @channel unless @channel_keys
 
       values = fetch_keys(record, @channel_keys)

--- a/test/plugin/test_out_slack.rb
+++ b/test/plugin/test_out_slack.rb
@@ -114,14 +114,29 @@ class SlackOutputTest < Test::Unit::TestCase
       create_driver(%[channel foo\nwebhook_url])
     end
 
-    # webhook_url is an empty string
+    # webhook_url is not empty, but channel is a empty string
+    assert_nothing_raised do
+      create_driver(%[webhook_url https://example.com/path/to/webhook])
+    end
+
+    # slackbot_url is an empty string
     assert_raise(Fluent::ConfigError) do
       create_driver(%[channel foo\nslackbot_url])
+    end
+
+    # slackbot is a string, without channel.
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[slackbot_url https://example.com/path/to/slackbot])
     end
 
     # token is an empty string
     assert_raise(Fluent::ConfigError) do
       create_driver(%[channel foo\ntoken])
+    end
+
+    # token is a string, without channel.
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[token some_token])
     end
   end
 

--- a/test/plugin/test_out_slack.rb
+++ b/test/plugin/test_out_slack.rb
@@ -114,7 +114,7 @@ class SlackOutputTest < Test::Unit::TestCase
       create_driver(%[channel foo\nwebhook_url])
     end
 
-    # webhook_url is not empty, but channel is a empty string
+    # webhook without channel (it works because webhook has a default channel)
     assert_nothing_raised do
       create_driver(%[webhook_url https://example.com/path/to/webhook])
     end
@@ -124,7 +124,7 @@ class SlackOutputTest < Test::Unit::TestCase
       create_driver(%[channel foo\nslackbot_url])
     end
 
-    # slackbot is a string, without channel.
+    # slackbot without channel
     assert_raise(Fluent::ConfigError) do
       create_driver(%[slackbot_url https://example.com/path/to/slackbot])
     end
@@ -134,7 +134,7 @@ class SlackOutputTest < Test::Unit::TestCase
       create_driver(%[channel foo\ntoken])
     end
 
-    # token is a string, without channel.
+    # slack webapi token without channel
     assert_raise(Fluent::ConfigError) do
       create_driver(%[token some_token])
     end


### PR DESCRIPTION
Currently, this fluent plugin always requires `channel` config.
But as mentioned in #19  , slack webhook does not need channel option.

So, I try to fix the issue in this pull request.

## Detail

This fluent plugin uses the channel config (String) as a hash key to building payloads from events in private methods.

So in this pull request, I add a constant `CHANNEL_NONE` (Symbol) to describe `channel config is nil`.
This code use `CHANNEL_NONE` as a hash key when `channel` config is `nil`.
