### PR TITLE
use @type instead of type in the example (as aa6ac233c)

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -1,9 +1,9 @@
 <source>
-  type forward
+  @type forward
 </source>
 
 <match tag> 
-  type slack
+  @type slack
   token "#{ENV['TOKEN']}"
   username fluentd
   color good


### PR DESCRIPTION
In the commit aa6ac23, README.md is updated along recommended notation.
But example.conf was not updated.