### PR TITLE
Fluent-plugin-slack as a filter

### DIFF
--- a/lib/fluent/plugin/filter_slack.rb
+++ b/lib/fluent/plugin/filter_slack.rb
@@ -1,0 +1,77 @@
+require 'fluent/plugin/filter_grep'
+
+require_relative 'slack_client'
+require_relative 'slack_common.rb'
+
+module Fluent
+  class SlackFilter < Fluent::Plugin::GrepFilter
+    Fluent::Plugin.register_filter('slack', self)
+
+    # For fluentd v0.12.16 or earlier
+    class << self
+      unless method_defined?(:desc)
+        def desc(description)
+        end
+      end
+    end
+
+    include SetTimeKeyMixin
+    include SetTagKeyMixin
+    include SlackCommon
+
+    config_set_default :include_time_key, true
+    config_set_default :include_tag_key, true
+
+    # for test
+    attr_reader :slack, :time_format, :localtime, :timef, :mrkdwn_in, :post_message_opts
+
+    def initialize
+      super
+      require 'uri'
+    end
+
+    SlackCommon.read_params(self)
+
+    def configure(conf)
+      conf['time_format'] ||= '%H:%M:%S' # old version compatiblity
+      conf['localtime'] ||= true unless conf['utc']
+      super
+      init_config()
+    end
+
+    def filter(tag, time, record)
+
+      unless super.nil?
+        begin
+          @slack.post_message(build_payloads(record, tag), @post_message_opts)
+        rescue Timeout::Error => e
+          log.warn "out_slack:", :error => e.to_s, :error_class => e.class.to_s
+          raise e # let Fluentd retry
+        rescue => e
+          log.error "out_slack:", :error => e.to_s, :error_class => e.class.to_s
+          log.warn_backtrace e.backtrace
+          # discard. @todo: add more retriable errors
+        end
+      end
+
+      record
+    end
+
+    private
+
+    Field = Struct.new("Field", :title, :value)
+    # ruby 1.9.x does not provide #to_h
+    Field.send(:define_method, :to_h) { {title: title, value: value} }
+
+    def build_payloads(record, tag)
+      if @title
+        build_title_payload_message(build_channel(record), { "tag" => Field.new(build_title(record), "#{build_message(record)}\n") })
+      elsif @color
+        build_color_payload_message(build_channel(record), "#{build_message(record)}\n")
+      else
+        build_plain_payload_message(build_channel(record), "#{build_message(record)}\n")
+      end
+    end
+
+  end
+end

--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -1,4 +1,5 @@
 require_relative 'slack_client'
+require_relative 'slack_common.rb'
 
 module Fluent
   class SlackOutput < Fluent::BufferedOutput
@@ -15,109 +16,12 @@ module Fluent
 
     include SetTimeKeyMixin
     include SetTagKeyMixin
+    include SlackCommon
 
     config_set_default :include_time_key, true
     config_set_default :include_tag_key, true
 
-    desc <<-DESC
-Incoming Webhook URI (Required for Incoming Webhook mode).
-See: https://api.slack.com/incoming-webhooks
-DESC
-    config_param :webhook_url,          :string, default: nil
-    desc <<-DESC
-Slackbot URI (Required for Slackbot mode).
-See https://api.slack.com/slackbot.
-NOTE: most of optional parameters such as `username`, `color`, `icon_emoji`,
-`icon_url`, and `title` are not available for this mode, but Desktop Notification
-via Highlight Words works with only this mode.
-DESC
-    config_param :slackbot_url,         :string, default: nil
-    desc <<-DESC
-Token for Web API (Required for Web API mode). See: https://api.slack.com/web.
-DESC
-    config_param :token,                :string, default: nil
-    desc "Name of bot."
-    config_param :username,             :string, default: nil
-    desc <<-DESC
-Color to use such as `good` or `bad`.
-See Color section of https://api.slack.com/docs/attachments.
-NOTE: This parameter must not be specified to receive Desktop Notification
-via Mentions in cases of Incoming Webhook and Slack Web API.
-DESC
-    config_param :color,                :string, default: nil
-    desc <<-DESC
-Emoji to use as the icon.
-Either of `icon_emoji` or `icon_url` can be specified.
-DESC
-    config_param :as_user,           :bool, default: nil
-    desc <<-DESC
-Post message as the authenticated user.
-NOTE: This parameter is only enabled if you use the Web API with your bot token.
-You cannot use both of `username` and `icon_emoji`(`icon_url`) when
-you set this parameter to `true`.
-DESC
-    config_param :icon_emoji,           :string, default: nil
-    desc <<-DESC
-Url to an image to use as the icon.
-Either of `icon_emoji` or `icon_url` can be specified.
-DESC
-    config_param :icon_url,             :string, default: nil
-    desc "Enable formatting. See: https://api.slack.com/docs/formatting."
-    config_param :mrkdwn,               :bool,   default: true
-    desc <<-DESC
-Find and link channel names and usernames.
-NOTE: This parameter must be `true` to receive Desktop Notification
-via Mentions in cases of Incoming Webhook and Slack Web API.
-DESC
-    config_param :link_names,           :bool,   default: true
-    desc <<-DESC
-Change how messages are treated. `none` or `full` can be specified.
-See Parsing mode section of https://api.slack.com/docs/formatting.
-DESC
-    config_param :parse,                :string, default: nil
-    desc <<-DESC
-Create channels if not exist. Not available for Incoming Webhook mode
-(since Incoming Webhook is specific to a channel).
-A web api token for Normal User is required.
-(Bot User can not create channels. See https://api.slack.com/bot-users)
-DESC
-    config_param :auto_channels_create, :bool,   default: false
-    desc "https proxy url such as https://proxy.foo.bar:443"
-    config_param :https_proxy,          :string, default: nil
-
-    desc "channel to send messages (without first '#')."
-    config_param :channel,              :string, default: nil
-    desc <<-DESC
-Keys used to format channel.
-%s will be replaced with value specified by channel_keys if this option is used.
-DESC
-    config_param :channel_keys,         default: nil do |val|
-      val.split(',')
-    end
-    desc <<-DESC
-Title format.
-%s will be replaced with value specified by title_keys.
-Title is created from the first appeared record on each tag.
-NOTE: This parameter must **not** be specified to receive Desktop Notification
-via Mentions in cases of Incoming Webhook and Slack Web API.
-DESC
-    config_param :title,                :string, default: nil
-    desc "Keys used to format the title."
-    config_param :title_keys,           default: nil do |val|
-      val.split(',')
-    end
-    desc <<-DESC
-Message format.
-%s will be replaced with value specified by message_keys.
-DESC
-    config_param :message,              :string, default: nil
-    desc "Keys used to format messages."
-    config_param :message_keys,         default: nil do |val|
-      val.split(',')
-    end
-
-    desc "Include messages to the fallback attributes"
-    config_param :verbose_fallback,     :bool,   default: false
+    SlackCommon.read_params(self)
 
     # for test
     attr_reader :slack, :time_format, :localtime, :timef, :mrkdwn_in, :post_message_opts
@@ -130,102 +34,8 @@ DESC
     def configure(conf)
       conf['time_format'] ||= '%H:%M:%S' # old version compatiblity
       conf['localtime'] ||= true unless conf['utc']
-
       super
-
-      if @channel
-        @channel = URI.unescape(@channel) # old version compatibility
-        if !@channel.start_with?('#') and !@channel.start_with?('@')
-          @channel = '#' + @channel # Add # since `#` is handled as a comment in fluentd conf
-        end
-      end
-
-      if @webhook_url
-        if @webhook_url.empty?
-          raise Fluent::ConfigError.new("`webhook_url` is an empty string")
-        end
-        unless @as_user.nil?
-          log.warn "out_slack: `as_user` parameter are not available for Incoming Webhook"
-        end
-        @slack = Fluent::SlackClient::IncomingWebhook.new(@webhook_url)
-      elsif @slackbot_url
-        if @slackbot_url.empty?
-          raise Fluent::ConfigError.new("`slackbot_url` is an empty string")
-        end
-        if @channel.nil?
-          raise Fluent::ConfigError.new("`channel` parameter required for Slackbot Remote Control")
-        end
-
-        if @username or @color or @icon_emoji or @icon_url
-          log.warn "out_slack: `username`, `color`, `icon_emoji`, `icon_url` parameters are not available for Slackbot Remote Control"
-        end
-        unless @as_user.nil?
-          log.warn "out_slack: `as_user` parameter are not available for Slackbot Remote Control"
-        end
-        @slack = Fluent::SlackClient::Slackbot.new(@slackbot_url)
-      elsif @token
-        if @token.empty?
-          raise Fluent::ConfigError.new("`token` is an empty string")
-        end
-        if @channel.nil?
-          raise Fluent::ConfigError.new("`channel` parameter required for Slack WebApi")
-        end
-
-        @slack = Fluent::SlackClient::WebApi.new
-      else
-        raise Fluent::ConfigError.new("One of `webhook_url` or `slackbot_url`, or `token` is required")
-      end
-      @slack.log = log
-      @slack.debug_dev = log.out if log.level <= Fluent::Log::LEVEL_TRACE
-
-      if @https_proxy
-        @slack.https_proxy = @https_proxy
-      end
-
-      @message      ||= '%s'
-      @message_keys ||= %w[message]
-      begin
-        @message % (['1'] * @message_keys.length)
-      rescue ArgumentError
-        raise Fluent::ConfigError, "string specifier '%s' for `message`  and `message_keys` specification mismatch"
-      end
-      if @title and @title_keys
-        begin
-          @title % (['1'] * @title_keys.length)
-        rescue ArgumentError
-          raise Fluent::ConfigError, "string specifier '%s' for `title` and `title_keys` specification mismatch"
-        end
-      end
-      if @channel && @channel_keys
-        begin
-          @channel % (['1'] * @channel_keys.length)
-        rescue ArgumentError
-          raise Fluent::ConfigError, "string specifier '%s' for `channel` and `channel_keys` specification mismatch"
-        end
-      end
-
-      if @icon_emoji and @icon_url
-        raise Fluent::ConfigError, "either of `icon_emoji` or `icon_url` can be specified"
-      end
-
-      if @as_user and (@icon_emoji or @icon_url or @username)
-        raise Fluent::ConfigError, "`username`, `icon_emoji` and `icon_url` cannot be specified when `as_user` is set to true"
-      end
-
-      if @mrkdwn
-        # Enable markdown for attachments. See https://api.slack.com/docs/formatting
-        @mrkdwn_in = %w[text fields]
-      end
-
-      if @parse and !%w[none full].include?(@parse)
-        raise Fluent::ConfigError, "`parse` must be either of `none` or `full`"
-      end
-
-      @post_message_opts = {}
-      if @auto_channels_create
-        raise Fluent::ConfigError, "`token` parameter is required to use `auto_channels_create`" unless @token
-        @post_message_opts = {auto_channels_create: true}
-      end
+      init_config()
     end
 
     def format(tag, time, record)
@@ -258,28 +68,6 @@ DESC
       end
     end
 
-    def common_payload
-      return @common_payload if @common_payload
-      @common_payload = {}
-      @common_payload[:as_user]    = @as_user    unless @as_user.nil?
-      @common_payload[:username]   = @username   if @username
-      @common_payload[:icon_emoji] = @icon_emoji if @icon_emoji
-      @common_payload[:icon_url]   = @icon_url   if @icon_url
-      @common_payload[:mrkdwn]     = @mrkdwn     if @mrkdwn
-      @common_payload[:link_names] = @link_names if @link_names
-      @common_payload[:parse]      = @parse      if @parse
-      @common_payload[:token]      = @token      if @token
-      @common_payload
-    end
-
-    def common_attachment
-      return @common_attachment if @common_attachment
-      @common_attachment = {}
-      @common_attachment[:color]     = @color     if @color
-      @common_attachment[:mrkdwn_in] = @mrkdwn_in if @mrkdwn_in
-      @common_attachment
-    end
-
     Field = Struct.new("Field", :title, :value)
     # ruby 1.9.x does not provide #to_h
     Field.send(:define_method, :to_h) { {title: title, value: value} }
@@ -294,20 +82,7 @@ DESC
         ch_fields[channel][per].value << "#{build_message(record)}\n"
       end
       ch_fields.map do |channel, fields|
-        fallback_text = if @verbose_fallback
-                          fields.values.map { |f| "#{f.title} #{f.value}" }.join(' ')
-                        else
-                          fields.values.map(&:title).join(' ')
-                        end
-
-        msg = {
-          attachments: [{
-            :fallback => fallback_text, # fallback is the message shown on popup
-            :fields   => fields.values.map(&:to_h)
-          }.merge(common_attachment)],
-        }
-        msg.merge!(channel: channel) if channel
-        msg.merge!(common_payload)
+        build_title_payload_message(channel, fields)
       end
     end
 
@@ -319,14 +94,7 @@ DESC
         messages[channel] << "#{build_message(record)}\n"
       end
       messages.map do |channel, text|
-        msg = {
-          attachments: [{
-            :fallback => text,
-            :text     => text,
-          }.merge(common_attachment)],
-        }
-        msg.merge!(channel: channel) if channel
-        msg.merge!(common_payload)
+        build_color_payload_message(channel, text)
       end
     end
 
@@ -338,41 +106,9 @@ DESC
         messages[channel] << "#{build_message(record)}\n"
       end
       messages.map do |channel, text|
-        msg = {text: text}
-        msg.merge!(channel: channel) if channel
-        msg.merge!(common_payload)
+        build_plain_payload_message(channel, text)
       end
     end
 
-    def build_message(record)
-      values = fetch_keys(record, @message_keys)
-      @message % values
-    end
-
-    def build_title(record)
-      return @title unless @title_keys
-
-      values = fetch_keys(record, @title_keys)
-      @title % values
-    end
-
-    def build_channel(record)
-      return nil if @channel.nil?
-      return @channel unless @channel_keys
-
-      values = fetch_keys(record, @channel_keys)
-      @channel % values
-    end
-
-    def fetch_keys(record, keys)
-      Array(keys).map do |key|
-        begin
-          record.fetch(key).to_s
-        rescue KeyError
-          log.warn "out_slack: the specified key '#{key}' not found in record. [#{record}]"
-          ''
-        end
-      end
-    end
   end
 end

--- a/lib/fluent/plugin/slack_common.rb
+++ b/lib/fluent/plugin/slack_common.rb
@@ -1,0 +1,294 @@
+require 'fluent/configurable'
+#require 'log'
+
+module SlackCommon
+  include Fluent::Configurable
+
+  def common_payload
+    return @common_payload if @common_payload
+    @common_payload = {}
+    @common_payload[:as_user]    = @as_user    unless @as_user.nil?
+    @common_payload[:username]   = @username   if @username
+    @common_payload[:icon_emoji] = @icon_emoji if @icon_emoji
+    @common_payload[:icon_url]   = @icon_url   if @icon_url
+    @common_payload[:mrkdwn]     = @mrkdwn     if @mrkdwn
+    @common_payload[:link_names] = @link_names if @link_names
+    @common_payload[:parse]      = @parse      if @parse
+    @common_payload[:token]      = @token      if @token
+    @common_payload
+  end
+
+  def common_attachment
+    return @common_attachment if @common_attachment
+    @common_attachment = {}
+    @common_attachment[:color]     = @color     if @color
+    @common_attachment[:mrkdwn_in] = @mrkdwn_in if @mrkdwn_in
+    @common_attachment
+  end
+
+  def build_message(record)
+    values = fetch_keys(record, @message_keys)
+    @message % values
+  end
+
+  def build_title(record)
+    return @title unless @title_keys
+
+    values = fetch_keys(record, @title_keys)
+    @title % values
+  end
+
+  def build_channel(record)
+    return nil if @channel.nil?
+    return @channel unless @channel_keys
+
+    values = fetch_keys(record, @channel_keys)
+    @channel % values
+  end
+
+  def fetch_keys(record, keys)
+    Array(keys).map do |key|
+      begin
+        record.fetch(key).to_s
+      rescue KeyError
+        log.warn "out_slack: the specified key '#{key}' not found in record. [#{record}]"
+        ''
+      end
+    end
+  end
+
+  def build_title_payload_message(channel, fields)
+    fallback_text = if @verbose_fallback
+                      fields.values.map { |f| "#{f.title} #{f.value}" }.join(' ')
+                    else
+                      fields.values.map(&:title).join(' ')
+                    end
+
+    msg = {
+      attachments: [{
+        :fallback => fallback_text, # fallback is the message shown on popup
+        :fields   => fields.values.map(&:to_h)
+      }.merge(common_attachment)],
+    }
+    msg.merge!(channel: channel) if channel
+    msg.merge!(common_payload)
+  end
+
+  def build_color_payload_message(channel, text)
+    msg = {
+      attachments: [{
+        :fallback => text,
+        :text     => text,
+      }.merge(common_attachment)],
+    }
+    msg.merge!(channel: channel) if channel
+    msg.merge!(common_payload)
+  end
+
+  def build_plain_payload_message(channel, text)
+    msg = {text: text}
+    msg.merge!(channel: channel) if channel
+    msg.merge!(common_payload)
+  end
+
+  def self.read_params(slack)
+
+    slack.desc <<-DESC
+Incoming Webhook URI (Required for Incoming Webhook mode).
+See: https://api.slack.com/incoming-webhooks
+DESC
+    slack.config_param :webhook_url,          :string, default: nil
+    slack.desc <<-DESC
+Slackbot URI (Required for Slackbot mode).
+See https://api.slack.com/slackbot.
+NOTE: most of optional parameters such as `username`, `color`, `icon_emoji`,
+`icon_url`, and `title` are not available for this mode, but Desktop Notification
+via Highlight Words works with only this mode.
+DESC
+    slack.config_param :slackbot_url,         :string, default: nil
+    slack.desc <<-DESC
+Token for Web API (Required for Web API mode). See: https://api.slack.com/web.
+DESC
+    slack.config_param :token,                :string, default: nil
+    desc "Name of bot."
+    slack.config_param :username,             :string, default: nil
+    slack.desc <<-DESC
+Color to use such as `good` or `bad`.
+See Color section of https://api.slack.com/docs/attachments.
+NOTE: This parameter must not be specified to receive Desktop Notification
+via Mentions in cases of Incoming Webhook and Slack Web API.
+DESC
+    slack.config_param :color,                :string, default: nil
+    slack.desc <<-DESC
+Emoji to use as the icon.
+Either of `icon_emoji` or `icon_url` can be specified.
+DESC
+    slack.config_param :as_user,           :bool, default: nil
+    slack.desc <<-DESC
+Post message as the authenticated user.
+NOTE: This parameter is only enabled if you use the Web API with your bot token.
+You cannot use both of `username` and `icon_emoji`(`icon_url`) when
+you set this parameter to `true`.
+DESC
+    slack.config_param :icon_emoji,           :string, default: nil
+    slack.desc <<-DESC
+Url to an image to use as the icon.
+Either of `icon_emoji` or `icon_url` can be specified.
+DESC
+    slack.config_param :icon_url,             :string, default: nil
+    desc "Enable formatting. See: https://api.slack.com/docs/formatting."
+    slack.config_param :mrkdwn,               :bool,   default: true
+    slack.desc <<-DESC
+Find and link channel names and usernames.
+NOTE: This parameter must be `true` to receive Desktop Notification
+via Mentions in cases of Incoming Webhook and Slack Web API.
+DESC
+    slack.config_param :link_names,           :bool,   default: true
+    slack.desc <<-DESC
+Change how messages are treated. `none` or `full` can be specified.
+See Parsing mode section of https://api.slack.com/docs/formatting.
+DESC
+    slack.config_param :parse,                :string, default: nil
+    slack.desc <<-DESC
+Create channels if not exist. Not available for Incoming Webhook mode
+(since Incoming Webhook is specific to a channel).
+A web api token for Normal User is required.
+(Bot User can not create channels. See https://api.slack.com/bot-users)
+DESC
+    slack.config_param :auto_channels_create, :bool,   default: false
+    desc "https proxy url such as https://proxy.foo.bar:443"
+    slack.config_param :https_proxy,          :string, default: nil
+
+    desc "channel to send messages (without first '#')."
+    slack.config_param :channel,              :string, default: nil
+    slack.desc <<-DESC
+Keys used to format channel.
+%s will be replaced with value specified by channel_keys if this option is used.
+DESC
+    slack.config_param :channel_keys,         default: nil do |val|
+      val.split(',')
+    end
+    slack.desc <<-DESC
+Title format.
+%s will be replaced with value specified by title_keys.
+Title is created from the first appeared record on each tag.
+NOTE: This parameter must **not** be specified to receive Desktop Notification
+via Mentions in cases of Incoming Webhook and Slack Web API.
+DESC
+    slack.config_param :title,                :string, default: nil
+    desc "Keys used to format the title."
+    slack.config_param :title_keys,           default: nil do |val|
+      val.split(',')
+    end
+    slack.desc <<-DESC
+Message format.
+%s will be replaced with value specified by message_keys.
+DESC
+    slack.config_param :message,              :string, default: nil
+    desc "Keys used to format messages."
+    slack.config_param :message_keys,         default: nil do |val|
+      val.split(',')
+    end
+
+    desc "Include messages to the fallback attributes"
+    slack.config_param :verbose_fallback,     :bool,   default: false
+
+  end
+
+  def init_config()
+    if @channel
+      @channel = URI.unescape(@channel) # old version compatibility
+      if !@channel.start_with?('#') and !@channel.start_with?('@')
+        @channel = '#' + @channel # Add # since `#` is handled as a comment in fluentd conf
+      end
+    end
+
+    if @webhook_url
+      if @webhook_url.empty?
+        raise Fluent::ConfigError.new("`webhook_url` is an empty string")
+      end
+      unless @as_user.nil?
+        log.warn "out_slack: `as_user` parameter are not available for Incoming Webhook"
+      end
+      @slack = Fluent::SlackClient::IncomingWebhook.new(@webhook_url)
+    elsif @slackbot_url
+      if @slackbot_url.empty?
+        raise Fluent::ConfigError.new("`slackbot_url` is an empty string")
+      end
+      if @channel.nil?
+        raise Fluent::ConfigError.new("`channel` parameter required for Slackbot Remote Control")
+      end
+
+      if @username or @color or @icon_emoji or @icon_url
+        log.warn "out_slack: `username`, `color`, `icon_emoji`, `icon_url` parameters are not available for Slackbot Remote Control"
+      end
+      unless @as_user.nil?
+        log.warn "out_slack: `as_user` parameter are not available for Slackbot Remote Control"
+      end
+      @slack = Fluent::SlackClient::Slackbot.new(@slackbot_url)
+    elsif @token
+      if @token.empty?
+        raise Fluent::ConfigError.new("`token` is an empty string")
+      end
+      if @channel.nil?
+        raise Fluent::ConfigError.new("`channel` parameter required for Slack WebApi")
+      end
+
+      @slack = Fluent::SlackClient::WebApi.new
+    else
+      raise Fluent::ConfigError.new("One of `webhook_url` or `slackbot_url`, or `token` is required")
+    end
+    @slack.log = log
+    @slack.debug_dev = log.out if log.level <= Fluent::Log::LEVEL_TRACE
+
+    if @https_proxy
+      @slack.https_proxy = @https_proxy
+    end
+
+    @message      ||= '%s'
+    @message_keys ||= %w[message]
+    begin
+      @message % (['1'] * @message_keys.length)
+    rescue ArgumentError
+      raise Fluent::ConfigError, "string specifier '%s' for `message`  and `message_keys` specification mismatch"
+    end
+    if @title and @title_keys
+      begin
+        @title % (['1'] * @title_keys.length)
+      rescue ArgumentError
+        raise Fluent::ConfigError, "string specifier '%s' for `title` and `title_keys` specification mismatch"
+      end
+    end
+    if @channel && @channel_keys
+      begin
+        @channel % (['1'] * @channel_keys.length)
+      rescue ArgumentError
+        raise Fluent::ConfigError, "string specifier '%s' for `channel` and `channel_keys` specification mismatch"
+      end
+    end
+
+    if @icon_emoji and @icon_url
+      raise Fluent::ConfigError, "either of `icon_emoji` or `icon_url` can be specified"
+    end
+
+    if @as_user and (@icon_emoji or @icon_url or @username)
+      raise Fluent::ConfigError, "`username`, `icon_emoji` and `icon_url` cannot be specified when `as_user` is set to true"
+    end
+
+    if @mrkdwn
+      # Enable markdown for attachments. See https://api.slack.com/docs/formatting
+      @mrkdwn_in = %w[text fields]
+    end
+
+    if @parse and !%w[none full].include?(@parse)
+      raise Fluent::ConfigError, "`parse` must be either of `none` or `full`"
+    end
+
+    @post_message_opts = {}
+    if @auto_channels_create
+      raise Fluent::ConfigError, "`token` parameter is required to use `auto_channels_create`" unless @token
+      @post_message_opts = {auto_channels_create: true}
+    end
+  end
+
+end

--- a/test/plugin/test_filter_slack.rb
+++ b/test/plugin/test_filter_slack.rb
@@ -1,0 +1,288 @@
+require_relative '../test_helper'
+require 'fluent/plugin/filter_slack'
+require 'time'
+require 'fluent/test/driver/filter'
+
+class SlackFilterTest < Test::Unit::TestCase
+
+  def setup
+    super
+    Fluent::Test.setup
+    @icon_url = 'http://www.google.com/s2/favicons?domain=www.google.de'
+  end
+
+  CONFIG = %[
+    channel channel
+    webhook_url https://hooks.slack.com/services/XXXX/XXXX/XXX
+  ]
+
+  def default_payload
+    {
+      channel:    '#channel',
+      mrkdwn:     true,
+      link_names: true,
+    }
+  end
+
+  def default_attachment
+    {
+      mrkdwn_in: %w[text fields],
+    }
+  end
+
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Filter.new(Fluent::SlackFilter).configure(conf)
+  end
+
+  # old version compatibility with v0.4.0"
+  def test_old_config
+    # default check
+    d = create_driver
+    assert_equal true, d.instance.localtime
+    assert_equal nil,  d.instance.username   # 'fluentd'    break lower version compatibility
+    assert_equal nil,  d.instance.color      # 'good'       break lower version compatibility
+    assert_equal nil,  d.instance.icon_emoji # ':question:' break lower version compatibility
+    assert_equal nil,  d.instance.icon_url
+    assert_equal true, d.instance.mrkdwn
+    assert_equal true, d.instance.link_names
+    assert_equal nil,  d.instance.parse
+
+    assert_nothing_raised do
+      create_driver(CONFIG + %[api_key testtoken])
+    end
+
+    # incoming webhook endpoint was changed. team option should be ignored
+    assert_nothing_raised do
+      create_driver(CONFIG + %[team sowasowa])
+    end
+
+    # rtm? it was not calling `rtm.start`. rtm option was removed and should be ignored
+    assert_nothing_raised do
+      create_driver(CONFIG + %[rtm true])
+    end
+
+    # channel should be URI.unescape-ed
+    d = create_driver(CONFIG + %[channel %23test])
+    assert_equal '#test', d.instance.channel
+
+    # timezone should work
+    d = create_driver(CONFIG + %[timezone Asia/Tokyo])
+    assert_equal 'Asia/Tokyo', d.instance.timezone
+  end
+
+  def test_configure
+    d = create_driver(%[
+      channel      channel
+      time_format  %Y/%m/%d %H:%M:%S
+      username     username
+      color        bad
+      icon_emoji   :ghost:
+      token        XX-XX-XX
+      title        slack notice!
+      message      %s
+      message_keys message
+    ])
+    assert_equal '#channel', d.instance.channel
+    assert_equal '%Y/%m/%d %H:%M:%S', d.instance.time_format
+    assert_equal 'username', d.instance.username
+    assert_equal 'bad', d.instance.color
+    assert_equal ':ghost:', d.instance.icon_emoji
+    assert_equal 'XX-XX-XX', d.instance.token
+    assert_equal '%s', d.instance.message
+    assert_equal ['message'], d.instance.message_keys
+
+    # Allow DM
+    d = create_driver(CONFIG + %[channel @test])
+    assert_equal '@test', d.instance.channel
+
+    assert_raise(Fluent::ConfigError) do
+      create_driver(CONFIG + %[title %s %s\ntitle_keys foo])
+    end
+
+    assert_raise(Fluent::ConfigError) do
+      create_driver(CONFIG + %[message %s %s\nmessage_keys foo])
+    end
+
+    assert_raise(Fluent::ConfigError) do
+      create_driver(CONFIG + %[channel %s %s\nchannel_keys foo])
+    end
+  end
+
+  def test_slack_configure
+    # One of webhook_url or slackbot_url, or token is required
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[channel foo])
+    end
+
+    # webhook_url is an empty string
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[channel foo\nwebhook_url])
+    end
+
+    # webhook without channel (it works because webhook has a default channel)
+    assert_nothing_raised do
+      create_driver(%[webhook_url https://example.com/path/to/webhook])
+    end
+
+    # slackbot_url is an empty string
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[channel foo\nslackbot_url])
+    end
+
+    # slackbot without channel
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[slackbot_url https://example.com/path/to/slackbot])
+    end
+
+    # token is an empty string
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[channel foo\ntoken])
+    end
+
+    # slack webapi token without channel
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[token some_token])
+    end
+  end
+
+  def test_timezone_configure
+    time = Time.parse("2014-01-01 22:00:00 UTC").to_i
+
+    d = create_driver(CONFIG + %[localtime])
+    with_timezone('Asia/Tokyo') do
+      assert_equal true,       d.instance.localtime
+      assert_equal "07:00:00", d.instance.timef.format(time)
+    end
+
+    d = create_driver(CONFIG + %[utc])
+    with_timezone('Asia/Tokyo') do
+      assert_equal false,      d.instance.localtime
+      assert_equal "22:00:00", d.instance.timef.format(time)
+    end
+
+    d = create_driver(CONFIG + %[timezone Asia/Taipei])
+    with_timezone('Asia/Tokyo') do
+      assert_equal "Asia/Taipei", d.instance.timezone
+      assert_equal "06:00:00",    d.instance.timef.format(time)
+    end
+  end
+
+  def test_time_format_configure
+    time = Time.parse("2014-01-01 22:00:00 UTC").to_i
+
+    d = create_driver(CONFIG + %[time_format %Y/%m/%d %H:%M:%S])
+    with_timezone('Asia/Tokyo') do
+      assert_equal "2014/01/02 07:00:00", d.instance.timef.format(time)
+    end
+  end
+
+  def test_buffer_configure
+    assert_nothing_raised do
+      create_driver(CONFIG + %[buffer_type file\nbuffer_path tmp/])
+    end
+  end
+
+  def test_icon_configure
+    # default
+    d = create_driver(CONFIG)
+    assert_equal nil, d.instance.icon_emoji
+    assert_equal nil, d.instance.icon_url
+
+    # either of icon_emoji or icon_url can be specified
+    assert_raise(Fluent::ConfigError) do
+      d = create_driver(CONFIG + %[icon_emoji :ghost:\nicon_url #{@icon_url}])
+    end
+
+    # icon_emoji
+    d = create_driver(CONFIG + %[icon_emoji :ghost:])
+    assert_equal ':ghost:', d.instance.icon_emoji
+    assert_equal nil, d.instance.icon_url
+
+    # icon_url
+    d = create_driver(CONFIG + %[icon_url #{@icon_url}])
+    assert_equal nil, d.instance.icon_emoji
+    assert_equal @icon_url, d.instance.icon_url
+  end
+
+  def test_link_names_configure
+    # default
+    d = create_driver(CONFIG)
+    assert_equal true, d.instance.link_names
+
+    # true
+    d = create_driver(CONFIG + %[link_names true])
+    assert_equal true, d.instance.link_names
+
+    # false
+    d = create_driver(CONFIG + %[link_names false])
+    assert_equal false, d.instance.link_names
+  end
+
+  def test_parse_configure
+    # default
+    d = create_driver(CONFIG)
+    assert_equal nil, d.instance.parse
+
+    # none
+    d = create_driver(CONFIG + %[parse none])
+    assert_equal 'none', d.instance.parse
+
+    # full
+    d = create_driver(CONFIG + %[parse full])
+    assert_equal 'full', d.instance.parse
+
+    # invalid
+    assert_raise(Fluent::ConfigError) do
+      d = create_driver(CONFIG + %[parse invalid])
+    end
+  end
+
+  def test_mrkwn_configure
+    # default
+    d = create_driver(CONFIG)
+    assert_equal true, d.instance.mrkdwn
+    assert_equal %w[text fields], d.instance.mrkdwn_in
+
+    # true
+    d = create_driver(CONFIG + %[mrkdwn true])
+    assert_equal true, d.instance.mrkdwn
+    assert_equal %w[text fields], d.instance.mrkdwn_in
+
+    # false
+    d = create_driver(CONFIG + %[mrkdwn false])
+    assert_equal false, d.instance.mrkdwn
+    assert_equal nil, d.instance.mrkdwn_in
+  end
+
+  def test_https_proxy_configure
+    # default
+    d = create_driver(CONFIG)
+    assert_equal nil, d.instance.slack.https_proxy
+    assert_equal Net::HTTP, d.instance.slack.proxy_class
+
+    # https_proxy
+    d = create_driver(CONFIG + %[https_proxy https://proxy.foo.bar:443])
+    assert_equal URI.parse('https://proxy.foo.bar:443'), d.instance.slack.https_proxy
+    assert_not_equal Net::HTTP, d.instance.slack.proxy_class # Net::HTTP.Proxy
+  end
+
+  def test_auto_channels_create_configure
+    # default
+    d = create_driver(CONFIG)
+    assert_equal false, d.instance.auto_channels_create
+    assert_equal({}, d.instance.post_message_opts)
+
+    # require `token`
+    assert_raise(Fluent::ConfigError) do
+      d = create_driver(CONFIG + %[auto_channels_create true])
+    end
+
+    # auto_channels_create
+    d = create_driver(CONFIG + %[auto_channels_create true\ntoken XXX-XX-XXX])
+    assert_equal true, d.instance.auto_channels_create
+    assert_equal({auto_channels_create: true}, d.instance.post_message_opts)
+  end
+
+  #Can't figure out how to adapt those "mock" tests...
+
+end


### PR DESCRIPTION
The point is to be able to use this plugin as a filter. Something like : 

```
  <filter>
    @type slack
    <regexp>
      key message
      pattern cool
    </regexp>
    webhook_url https://hooks.slack.com/services/XXX/XXX/XXX
    channel @pbenefice
    username fluent-slack
    icon_emoji :ghost:
  </filter>
```

What I tried to do : 

1. Re-use as much code as possible by splitting it in a `slack_common` namespace
2. Inherit from `GrepFilter` for the filter, to be able to only send slack notification when matching regex pattern
3. Copy tests from the output to apply it to the filter : I'm stuck at the *mock* tests, can't figure out how to replicate this for the filter..

If you have any feedback, or maybe time to help me a bit with those tests :p

Best regards