### PR TITLE
Allow fetching key values from nested hash

### DIFF
--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -367,12 +367,22 @@ DESC
     def fetch_keys(record, keys)
       Array(keys).map do |key|
         begin
-          record.fetch(key).to_s
+          fetch_key(record, key).to_s
         rescue KeyError
           log.warn "out_slack: the specified key '#{key}' not found in record. [#{record}]"
           ''
         end
       end
     end
+
+    def fetch_key(record, key)
+      if key.include? "."
+        match = key.match(/^([a-zA-Z0-9-_]*).([a-zA-Z0-9-_.]*)/)
+        fetch_key(record.fetch(match[1]), match[2])
+      else
+        record.fetch(key)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hi @sonots,

I would like to be able to fetch keys from hash if there is any within the record.
For example if using this [kubernetes plugin](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#example-inputoutput), I'd like to be able to use the kubernetes_namespace within the message for example.

In order to do that, I considered that key which contain a "." could be interpreted as an attempt to access a nested hash. So if there is any dot, I extract the value of "the first key" (at the left of the first dot), extract the corresponding part of the record and call the same function with that piece of record and what remain of the key.

As an example, this record : 

```
{"json":"message", "hash":{"random":"test", "sub-key":{"sub-sub_key":"Im a sub sub key"}  } }
```

With this config for the message : 

```
<match tag.test>
  @type slack
  message %s
  message_keys hash.sub-key.sub-sub_key
</match>
```

Should return : *Im a sub sub key*

What do you think ?

Best regards