### PR TITLE
Added escape_symbols config param

### DIFF
--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -119,6 +119,9 @@ DESC
     desc "Include messages to the fallback attributes"
     config_param :verbose_fallback,     :bool,   default: false
 
+    desc "Escape special symbols in message"
+    config_param :escape_symbols,       :bool,   default: true
+
     # for test
     attr_reader :slack, :time_format, :localtime, :timef, :mrkdwn_in, :post_message_opts
 


### PR DESCRIPTION
Currently the plug-in automatically escapes the special symbols in the message. This is restrictive if the message contains links, e.g:
```json
"message": "This is a link: <https://github.com|github>"
```
Added a flag `escape_symbols` which can disable escaping symbols. 

*Edit:* Not sure why certain tests are failing, I was able to run those locally.