### PR TITLE
Stop adding '#' to channel

### DIFF
--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -135,9 +135,6 @@ DESC
 
       if @channel
         @channel = URI.unescape(@channel) # old version compatibility
-        if !@channel.start_with?('#') and !@channel.start_with?('@')
-          @channel = '#' + @channel # Add # since `#` is handled as a comment in fluentd conf
-        end
       end
 
       if @webhook_url

--- a/test/plugin/test_out_slack.rb
+++ b/test/plugin/test_out_slack.rb
@@ -81,7 +81,7 @@ class SlackOutputTest < Test::Unit::TestCase
       message      %s
       message_keys message
     ])
-    assert_equal '#channel', d.instance.channel
+    assert_equal 'channel', d.instance.channel
     assert_equal '%Y/%m/%d %H:%M:%S', d.instance.time_format
     assert_equal 'username', d.instance.username
     assert_equal 'bad', d.instance.color


### PR DESCRIPTION
If channel has '#' + id (e.g. '#C12345678'), Slack Incoming Webhook of Custom Integration retrurns '404 channel_not_found'.

Channel has name without '#' or with '#' goes well.
