### PR TITLE
Replace deprecated unescape call

### DIFF
--- a/lib/fluent/plugin/out_slack.rb
+++ b/lib/fluent/plugin/out_slack.rb
@@ -134,7 +134,7 @@ DESC
       super
 
       if @channel
-        @channel = URI.unescape(@channel) # old version compatibility
+        @channel = CGI.unescape(@channel) # old version compatibility
         if !@channel.start_with?('#') and !@channel.start_with?('@')
           @channel = '#' + @channel # Add # since `#` is handled as a comment in fluentd conf
         end


### PR DESCRIPTION
URI.unescape => CGI.unescape

Fixes this plugin breaking with newer versions of ruby / fluentd (tested with ruby 3.1.3p185 and fluentd 1.15.3)